### PR TITLE
Add warning - do not use special chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,3 +286,8 @@ ASS字幕字体子集化 MKV批量提取/生成
 - 字幕语言代码表:
 
   [点此获取](https://www.science.co.il/language/Codes.php)
+  
+  
+## Warning
+**No escape of specsial chars and quotes to avoid string splitting and sub folders**
+Track names with `/` or other special chars will break mkvtool. Same goes for font name wirh `'!#` or other special chars. Arguments are not qouted & escaped for cli mkvmerge


### PR DESCRIPTION
## Problem track name
```bash
mkvpropedit test.mkv --edit track:s1 --set name="test / test"
```
Will create a folder `test`  with a `test.ass` and will not be found to get analyze.

## Fonts with special chars
Examples of public fonts with special chars
- `#` https://www.dafont.com/44font.font -> test will be a comment
- `'` https://www.dafont.com/briannes-hand.font -> will start a quote
- `!` https://www.dafont.com/go-boom.font