### PR TITLE
Handle huge subs

### DIFF
--- a/mkvlib/ass.go
+++ b/mkvlib/ass.go
@@ -216,6 +216,16 @@ func (self *assProcessor) parse() bool {
 						}
 						_name := fmt.Sprintf("%s^%s", name, strings.Join(arr, " "))
 						m[_name] += __item.Text
+                                                if len(m[_name]) > 1000 {
+                                                        chars := make(map[rune]int)
+                                                        for _, char := range m[_name] {
+                                                                chars[char]++
+                                                        }
+                                                        m[_name] = ""
+                                                        for char := range chars {
+                                                                m[_name] += string(char)
+                                                        }
+                                                }
 					}
 				}
 			}


### PR DESCRIPTION
I tested different values and 1000 was the fastest.

Extending the string after > 1000 chars gets slower and slower and  huge subs need sometimes hours.

**Solution**
`> 1000 chars` -> make every char `unique`

---

Different solution could be to add all chars to an array (all the time), but a test was slower and the other code worked