### PR TITLE
Quote and escape

### DIFF
--- a/mkvlib/p.go
+++ b/mkvlib/p.go
@@ -6,10 +6,17 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 func newProcess(stdin io.Reader, stdout, stderr io.Writer, dir, prog string, args ...string) (p *os.Process, err error) {
 	cmd := exec.Command(prog, args...)
+
+	for index := range args {
+		args[index] = strings.ReplaceAll(args[index], "!", "\\!")
+		args[index] = "\"" + args[index] + "\""
+	}
+	
 	if dir != "" {
 		cmd.Dir = dir
 	}


### PR DESCRIPTION
Avoids a lot of split issues split issues with special chars in font names or in Subtitle names.
`!` was last char that broke the command.

*Didn't find any escape function in Golang os exec*