### PR TITLE
Do not add newline

### DIFF
--- a/mkvlib/ass.go
+++ b/mkvlib/ass.go
@@ -215,7 +215,7 @@ func (self *assProcessor) parse() bool {
 							arr = append(arr, "Regular")
 						}
 						_name := fmt.Sprintf("%s^%s", name, strings.Join(arr, " "))
-						s := m[_name] + __item.Text
+						s := m[_name] + strings.ReplaceAll(strings.ReplaceAll(__item.Text, "\\n", ""), "\\N", "")
 						if len(s) > 1000 {
 							_m := make(map[rune]bool)
 							chars := make([]rune, 0)


### PR DESCRIPTION
`\` is uncommon in a lot of fonts and will complain about missing char