### PR TITLE
Fix errors in python sdk

### DIFF
--- a/mkvlib/sdk/exports.go
+++ b/mkvlib/sdk/exports.go
@@ -22,7 +22,7 @@ func _lcb(lcb C.logCallback) func(byte, string) {
 
 //export InitInstance
 func InitInstance(lcb C.logCallback) {
-	getter.InitProcessorInstance(_lcb(lcb))
+	processor = getter.InitProcessorInstance(_lcb(lcb))
 }
 
 //export GetMKVInfo

--- a/mkvlib/sdk/sdk.py
+++ b/mkvlib/sdk/sdk.py
@@ -22,7 +22,7 @@ def version():
 
 def initInstance(lcb):
     call = lib.InitInstance
-    call(_lcb(lcb)
+    call(_lcb(lcb))
 
 
 def getMKVInfo(file):
@@ -89,7 +89,7 @@ def createTestVideo(asses, s, fontdir, enc, burn, lcb):
     call(_files.encode(), s.encode(), fontdir.encode(), enc.encode(), burn, _lcb(lcb))
 
 def ass2pgs(asses, resolution, frameRate, fontdir, output):
-    call = lib.Ass2Pgs()
+    call = lib.Ass2Pgs
     _files = dumps(asses)
     call(_files.encode(), resolution.encode(), frameRate.encode(), fontdir.encode(), output.encode())
 


### PR DESCRIPTION
#### Description
This Pull Request addresses the following issues:

1. In the `exports.go` file, the `InitInstance` function did not assign the result of `getter.InitProcessorInstance(_lcb(lcb))` to `processor`, causing `processor` to not be properly initialized. This has been fixed by changing it to `processor = getter.InitProcessorInstance(_lcb(lcb))`.

2. In the `sdk.py` file, the `ass2pgs` function was incorrectly called as `call = lib.Ass2Pgs()`. This has been corrected to `call = lib.Ass2Pgs` to properly reference the function.

#### Changes
- **`exports.go`**:
  - Fixed the `InitInstance` function to ensure `processor` is properly initialized.

- **`sdk.py`**:
  - Fixed the `ass2pgs` function call to correctly reference `lib.Ass2Pgs`.

#### Impact
These fixes ensure that the `InitInstance` function correctly initializes `processor` and that the `ass2pgs` function properly calls the underlying library function, avoiding potential runtime errors.